### PR TITLE
Handle error conditions for publishsettings import

### DIFF
--- a/azure_cli/azure_account.py
+++ b/azure_cli/azure_account.py
@@ -107,17 +107,25 @@ class AzureAccount:
             )
 
     def __read_xml(self):
-        self.settings = self.config.get_option('publishsettings')
-        return minidom.parse(self.settings)
+        try:
+            self.settings = self.config.get_option('publishsettings')
+            return minidom.parse(self.settings)
+        except Exception as e:
+            raise AzureSubscriptionParseError('%s (%s)' % (type(e), str(e)))
 
     def __read_p12(self):
         xml = self.__read_xml()
-        profile = xml.getElementsByTagName('Subscription')
         try:
+            profile = xml.getElementsByTagName('Subscription')
             cert = profile[0].attributes['ManagementCertificate'].value
         except:
             raise AzureManagementCertificateNotFound(
                 "No PublishProfile.ManagementCertificate found in %s" %
                 self.settings
             )
-        return load_pkcs12(cert.decode("base64"), '')
+        try:
+            return load_pkcs12(cert.decode("base64"), '')
+        except Exception as e:
+            raise AzureSubscriptionCertDecodeError(
+                '%s (%s)' % (type(e), str(e))
+            )

--- a/azure_cli/azure_account.py
+++ b/azure_cli/azure_account.py
@@ -86,15 +86,25 @@ class AzureAccount:
 
     def __get_private_key(self):
         p12 = self.__read_p12()
-        return dump_privatekey(
-            FILETYPE_PEM, p12.get_privatekey()
-        )
+        try:
+            return dump_privatekey(
+                FILETYPE_PEM, p12.get_privatekey()
+            )
+        except Exception as e:
+            raise AzureSubscriptionDecodeError(
+                '%s (%s)' % (type(e), str(e))
+            )
 
     def __get_certificate(self):
         p12 = self.__read_p12()
-        return dump_certificate(
-            FILETYPE_PEM, p12.get_certificate()
-        )
+        try:
+            return dump_certificate(
+                FILETYPE_PEM, p12.get_certificate()
+            )
+        except Exception as e:
+            raise AzureSubscriptionDecodeError(
+                '%s (%s)' % (type(e), str(e))
+            )
 
     def __get_subscription_id(self):
         xml = self.__read_xml()
@@ -126,6 +136,6 @@ class AzureAccount:
         try:
             return load_pkcs12(cert.decode("base64"), '')
         except Exception as e:
-            raise AzureSubscriptionCertDecodeError(
+            raise AzureSubscriptionDecodeError(
                 '%s (%s)' % (type(e), str(e))
             )

--- a/azure_cli/azurectl_exceptions.py
+++ b/azure_cli/azurectl_exceptions.py
@@ -29,6 +29,14 @@ class AzureConfigParseError(AzureError):
     pass
 
 
+class AzureSubscriptionParseError(AzureError):
+    pass
+
+
+class AzureSubscriptionCertDecodeError(AzureError):
+    pass
+
+
 class AzureHelpNoCommandGiven(AzureError):
     pass
 

--- a/azure_cli/azurectl_exceptions.py
+++ b/azure_cli/azurectl_exceptions.py
@@ -33,7 +33,7 @@ class AzureSubscriptionParseError(AzureError):
     pass
 
 
-class AzureSubscriptionCertDecodeError(AzureError):
+class AzureSubscriptionDecodeError(AzureError):
     pass
 
 

--- a/test/data/config.invalid_publishsettings_cert
+++ b/test/data/config.invalid_publishsettings_cert
@@ -1,0 +1,4 @@
+[default]
+storage_account_name = bob
+storage_container_name = foo
+publishsettings = ../data/publishsettings_invalid_cert

--- a/test/data/config.invalid_publishsettings_subscription
+++ b/test/data/config.invalid_publishsettings_subscription
@@ -1,0 +1,4 @@
+[default]
+storage_account_name = bob
+storage_container_name = foo
+publishsettings = ../data/publishsettings_missing_subscription

--- a/test/data/publishsettings.missing_subscription
+++ b/test/data/publishsettings.missing_subscription
@@ -1,0 +1,3 @@
+<PublishData>
+  <PublishProfile SchemaVersion="2.0"/>
+</PublishData>

--- a/test/data/publishsettings_invalid_cert
+++ b/test/data/publishsettings_invalid_cert
@@ -1,0 +1,5 @@
+<PublishData>
+  <PublishProfile SchemaVersion="2.0">
+     <Subscription Id="4711" Name="azure" ManagementCertificate="dGVzdA=="/>
+  </PublishProfile>
+</PublishData>

--- a/test/unit/azure_account_test.py
+++ b/test/unit/azure_account_test.py
@@ -30,6 +30,20 @@ class TestAzureAccount:
     def test_storage_container(self):
         assert self.account.storage_container() == 'foo'
 
+    @raises(AzureSubscriptionParseError)
+    def test_publishsettings_missing_subscription(self):
+        account_invalid = AzureAccount(
+            'default', '../data/config.invalid_publishsettings_subscription'
+        )
+        account_invalid.publishsettings()
+
+    @raises(AzureSubscriptionDecodeError)
+    def test_publishsettings_invalid_cert(self):
+        account_invalid = AzureAccount(
+            'default', '../data/config.invalid_publishsettings_cert'
+        )
+        account_invalid.publishsettings()
+
     @patch('azure_cli.azure_account.dump_privatekey')
     @patch('azure_cli.azure_account.dump_certificate')
     def test_publishsettings(self, mock_dump_pkey, mock_dump_certificate):


### PR DESCRIPTION
Exceptions for invalid XML and/or missing Subscription section
are captured as well es decoding errors from pkcs12/base64
decryption
