### PR TITLE
Change travis config to allow use of container service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
-sudo: required
+sudo: false
 
 python:
   - "2.7"


### PR DESCRIPTION
We don't need to `sudo` anything, so lets get off the overloaded VM service and use the shiny new container service.

