### PR TITLE
Added file type identification for upload source

### DIFF
--- a/azure_cli/compute_storage_task.py
+++ b/azure_cli/compute_storage_task.py
@@ -17,7 +17,7 @@ usage: azurectl compute storage -h | --help
        azurectl compute storage container list
        azurectl compute storage container show
            [--container=<container>]
-       azurectl compute storage upload --source=<xzfile> --name=<blobname>
+       azurectl compute storage upload --source=<file> --name=<blobname>
            [--max-chunk-size=<size>]
            [--container=<container>]
            [--quiet]
@@ -38,8 +38,8 @@ commands:
         upload xz compressed blob to the given container
     delete
         delete blob from the given container
-    --source=<xzfile>
-        XZ compressed data file
+    --source=<file>
+        file to upload
     --name=<name>
         name of the file in the storage pool
     --max-chunk-size=<size>

--- a/azure_cli/filetype.py
+++ b/azure_cli/filetype.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2015 SUSE Linux GmbH.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import re
+import subprocess
+
+
+class FileType:
+    """
+        map file magic information to type methods
+    """
+    def __init__(self, file_name):
+        file_info = subprocess.Popen(
+            ['file', file_name],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
+        self.filetype = file_info.communicate()[0]
+
+    def is_xz(self):
+        if re.match('.*: XZ compressed', self.filetype):
+            return True
+        return False

--- a/azure_cli/xz.py
+++ b/azure_cli/xz.py
@@ -70,6 +70,10 @@ class XZ:
         return chunks
 
     @classmethod
+    def close(self):
+        self.lzma_stream.close()
+
+    @classmethod
     def open(self, file_name, buffer_size=LZMA_STREAM_BUFFER_SIZE):
         self.lzma_stream = open(file_name, 'rb')
         return XZ(self.lzma_stream, buffer_size)

--- a/doc/man/Makefile
+++ b/doc/man/Makefile
@@ -17,5 +17,8 @@ install:
 		install -m 644 $$i ${man_prefix}/man1 ;\
 	done
 
+show:
+	zcat *.gz | nroff -man | less
+
 clean:
 	rm -f *.1.gz

--- a/doc/man/azurectl::compute::storage.md
+++ b/doc/man/azurectl::compute::storage.md
@@ -4,14 +4,16 @@ azurectl - Command Line Interface to manage Microsoft Azure
 
 # SYNOPSIS
 
-__azurectl__ compute storage upload --source=*xzfile* --name=*blobname*
+__azurectl__ compute storage upload --source=*file* --name=*blobname*
 __azurectl__ compute storage delete --name=*blobname*
 
 # DESCRIPTION
 
 ## __upload__
 
-Upload an XZ compressed file to a container. While any kind of data can be uploaded to the blob storage the purpose of this command is mainly for uploading VHD (Virtual Hard Drive) disk images in order to register an Azure operating system image from it at a later point in time
+Upload file to a container. The command autodetects the filetype whether it is compressed or not and applies the appropriate decompressor. If the filetype could not be identified the file will be uploaded as raw sequence of bytes
+
+While any kind of data can be uploaded to the blob storage the purpose of this command is mainly for uploading XZ compressed VHD (Virtual Hard Drive) disk images in order to register an Azure operating system image from it at a later point in time.
 
 ## __delete__
 

--- a/test/unit/filetype_test.py
+++ b/test/unit/filetype_test.py
@@ -1,0 +1,13 @@
+from nose.tools import *
+
+from azure_cli.filetype import FileType
+
+from azure_cli.azurectl_exceptions import *
+
+
+class TestFileType:
+    def setup(self):
+        self.filetype = FileType('../data/blob.xz')
+
+    def test_is_xz(self):
+        assert self.filetype.is_xz() == True

--- a/test/unit/storage_test.py
+++ b/test/unit/storage_test.py
@@ -34,7 +34,7 @@ class TestStorage:
     @patch('azure_cli.storage.XZ.uncompressed_size')
     def test_upload(self, mock_uncompressed_size):
         mock_uncompressed_size.return_value = 1024
-        self.storage.upload('../data/config', None, 1024)
+        self.storage.upload('../data/blob.xz', None, 1024)
 
     @raises(AzureStorageDeleteError)
     def test_delete(self):


### PR DESCRIPTION
The azurectl compute storage upload command will now detect the
filetype and apply the decompression only for detected types.
If no supported decompressor type is found the file is uploaded
as it is
